### PR TITLE
html now generates only on change events

### DIFF
--- a/scripts/ColonyMinerals.js
+++ b/scripts/ColonyMinerals.js
@@ -7,7 +7,7 @@ export const colonyMinerals = () => {
     const colonymins = getColonyMinerals()
     let html = ""
     for (const colmin of colonymins) {
-        html += `<li>${colmin.ton} tons of ${colmin.id}`
+        html += `<li>${colmin.ton} tons of ${colmin.id}</li>`
     }
 
     return html
@@ -23,7 +23,7 @@ export const colonyMinerals = () => {
 //     colonyMinerals.map(buildOrderListItem)
 
 //     html += listItems.join("")
-    
+
 //     html += "</ul>"
 
 //     return html

--- a/scripts/Exomine.js
+++ b/scripts/Exomine.js
@@ -2,11 +2,12 @@ import { Facilities } from "./Facilities.js"
 import { FacilityMinerals } from "./FacilityMinerals.js"
 import { Governors } from "./Governors.js"
 import { purchaseMineral } from "./database.js"
+import { colonyMinerals } from "./ColonyMinerals.js"
 
 document.addEventListener(
     "click",
     (event) => {
-        if(event.target.id === "orderButton"){
+        if (event.target.id === "orderButton") {
             purchaseMineral()
         }
     }
@@ -30,7 +31,7 @@ export const Exomine = () => {
             </div>
             <div class = "section colony-resources">
                 <h2>Available Resources for Colony</h2>
-            
+                ${colonyMinerals()}
             </div>
         </section>
         <section id="bottom-section">

--- a/scripts/Facilities.js
+++ b/scripts/Facilities.js
@@ -3,31 +3,10 @@
 import { getFacilities, setFacility, setMineral } from "./database.js";
 import { FacilityMinerals } from "./FacilityMinerals.js";
 
-const facilities = getFacilities() 
+const facilities = getFacilities()
 
-// export const renderFacilityMinerals = () => {
-//     document.addEventListener(
-//         "change",
-//         (event) => {
-//             if (event.target.id === "facilityResource") {
-//                 FacilityMinerals()
-//             } 
-//         }
-//     )
-// }
-document.addEventListener(
-    "change",
-    (changeEvent) => {
-        if (changeEvent.target.id === "facilityResource") {
-                for (const facility of facilities) {
-                    if (parseInt(changeEvent.target.value) === facility.id){
-                        setFacility(facility.id)
-                    }
-                }
-        }
-})
 
-    export const Facilities = () => {
+export const Facilities = () => {
     let html = ""
 
     html += `<select id="facilityResource">

--- a/scripts/FacilityMinerals.js
+++ b/scripts/FacilityMinerals.js
@@ -1,36 +1,54 @@
-import { getFacilities, getFacilityMinerals, setMineral} from "./database.js"
+import { getFacilities, getFacilityMinerals, getMinerals, setFacility } from "./database.js"
 
-// make a function that generates HTML that displays the current facility's mineral inventory (minerals listed is dependent on facility chosen from drop down)
-const facilityMineralsArr  = getFacilityMinerals()
-const facilitiesArr = getFacilities()
+
+let clickFacilityId = 0
+
+const facilities = getFacilities()
 
 document.addEventListener(
     "change",
     (changeEvent) => {
-        if (changeEvent.target.name === "facilityMinerals") {
-                for (const facilityMineralObj of facilityMineralsArr) {
-                    if (parseInt(changeEvent.target.value) === facilityMineralObj.id){
-                        setMineral(facilityMineralObj.mineralId)
-                    }
+        if (changeEvent.target.id === "facilityResource") {
+            clickFacilityId = parseInt(changeEvent.target.value)
+            for (const facility of facilities) {
+                if (parseInt(changeEvent.target.value) === facility.id) {
+                    setFacility(facility.id)
                 }
+            }
         }
-})
+    })
 
+const buildFacilityMineralsList = (facilityMineralObj) => {
+    const facilities = getFacilities()
+    const minerals = getMinerals()
+
+    const foundFacility = facilities.find(
+        facility => {
+            return facility.id === facilityMineralObj.facilityId
+        }
+    )
+    const foundMineral = minerals.find(
+        mineral => {
+            return mineral.id === facilityMineralObj.mineralId
+        }
+    )
+
+    return `<li>
+            <input type="radio" name="facilityMinerals" value="${foundFacility.id}" /> ${facilityMineralObj.ton} tons of ${foundMineral.mineral} at ${foundFacility.facility}
+            </li>`
+}
 export const FacilityMinerals = () => {
-    let html = "<ul>"
-    // This is how you have been converting objects to <li> elements
-    for (const facilityMineralObj of facilityMineralsArr) {
-        // for (const facilityObj of facilitiesArr) {
-        //     if (facilityMineralObj.facilityId === facilityObj.id) {
-                html += `<li>
-                    <input type="radio" name="facilityMinerals" value="${facilityMineralObj.id}" /> ${facilityMineralObj.ton} tons of ${facilityMineralObj.id}
-                </li>`
-        //     }
-        // }
+    const facilityMineralsArr = getFacilityMinerals()
+
+    let html = ""
+    if (clickFacilityId > 0) {
+        html = "<ul>"
+
+        const listItems = facilityMineralsArr.map(buildFacilityMineralsList)
+
+        html += listItems.join("")
+        html += "</ul>"
     }
-    html += "</ul>"
 
     return html
 }
-
-// make a function that generates HTML radio buttons for the user to select a certain mineral listed

--- a/scripts/Governors.js
+++ b/scripts/Governors.js
@@ -11,15 +11,15 @@ document.addEventListener(
     "change",
     (changeEvent) => {
         if (changeEvent.target.id === "resource") {
-                for (const governor of governors) {
-                    if (parseInt(changeEvent.target.value) === governor.id){
-                        setColony(governor.colonyId)
-                        colonyMinerals()
-                    }
+            for (const governor of governors) {
+                if (parseInt(changeEvent.target.value) === governor.id) {
+                    setColony(governor.colonyId)
+                    colonyMinerals()
                 }
+            }
         }
-})
- 
+    })
+
 // governors function provides html for gov options in dropdown format
 export const Governors = () => {
     let html = ""

--- a/scripts/database.js
+++ b/scripts/database.js
@@ -135,6 +135,9 @@ export const getFacilities = () => {
 export const getFacilityMinerals = () => {
     return database.facilityMinerals.map(f => ({...f}))
 }
+export const getColonyMinerals = () => {
+    return database.colonyMinerals.map(f => ({...f}))
+}
 export const getTransientState = () => {
     // find a method to return a COPY of the object
     let copyOfTransientState = Object.assign({}, database.transientState)

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -6,4 +6,12 @@ const renderAllHTML = () => {
     mainContainer.innerHTML = Exomine()
 }
 
+
 renderAllHTML()
+
+document.addEventListener("stateChanged",
+    event => {
+        console.log("state changed, regenerating HTML...")
+        renderAllHTML()
+    }
+)


### PR DESCRIPTION
supports feature request #2 

# Description

Added conditionals inside of the change event listeners in order to generate HTML only when a certain condition is met (i.e. an option was selected from the facility dropdown menu

Fixes #2 (partially)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested inside the brower. The html generates only when a user selects a facility from the dropdown menu

- [x] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
